### PR TITLE
Upgrade maven assembly plugin to properly handle multi-release jars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.3.0</version>
                 <configuration>
                     <appendAssemblyId>false</appendAssemblyId>
                     <descriptorRefs>


### PR DESCRIPTION
This PR intends to fix *Problem with FlatLaf Look & Feel dependencies with Java 11 on Windows 10* (https://github.com/gaborbata/jpass/issues/19)